### PR TITLE
Fix issues with Python 3 compatibility

### DIFF
--- a/tftb/generators/frequency_modulated.py
+++ b/tftb/generators/frequency_modulated.py
@@ -105,7 +105,7 @@ def fmlin(n_points, fnormi=0.0, fnormf=0.5, t0=None):
         y = fnormi * (y - t0) + ((fnormf - fnormi) / (2.0 * (n_points - 1))) * \
             ((y - 1) ** 2 - (t0 - 1) ** 2)
         y = np.exp(1j * 2.0 * np.pi * y)
-        y = y / y[t0 - 1]
+        y = y / y[int(t0) - 1]
         iflaw = np.linspace(fnormi, fnormf, n_points)
         return y, iflaw
 

--- a/tftb/generators/noise.py
+++ b/tftb/generators/noise.py
@@ -12,9 +12,9 @@ def noisecu(n_points):
     :rtype: numpy.ndarray
     :Examples:
     >>> noise = noisecu(512)
-    >>> print noise.mean()
+    >>> print(noise.mean())
     0.0
-    >>> print std(noise) ** 2
+    >>> print(std(noise) ** 2)
     1.0
     >>> subplot(211), plot(real(noise))
     >>> subplot(212), plot(linspace(-0.5, 0.5, 512), abs(fftshift(fft(noise))) ** 2)
@@ -47,9 +47,9 @@ def noisecg(n_points, a1=None, a2=None):
     :rtype: numpy.ndarray
     :Examples:
     >>> noise = noisecg(512)
-    >>> print noise.mean()
+    >>> print(noise.mean())
     0.0
-    >>> print std(noise) ** 2
+    >>> print(std(noise) ** 2)
     1.0
     >>> subplot(211), plot(real(noise))
     >>> subplot(212), plot(linspace(-0.5, 0.5, 512), abs(fftshift(fft(noise))) ** 2)

--- a/tftb/processing/freq_domain.py
+++ b/tftb/processing/freq_domain.py
@@ -13,9 +13,9 @@ def locfreq(signal):
     :Example:
     >>> z = amgauss(160, 80, 50)
     >>> fm, B = locfreq(z)
-    >>> print fm
+    >>> print(fm)
     -9.1835e-14
-    >>> print B
+    >>> print(B)
     0.02
     """
     if signal.ndim > 1:

--- a/tftb/processing/postprocessing.py
+++ b/tftb/processing/postprocessing.py
@@ -223,4 +223,4 @@ if __name__ == '__main__':
     s = atoms(64, np.array([[32, 0.3, 16, 1]]))
     spec = Spectrogram(s)
     tfr, t, f = spec.run()
-    print renyi_information(tfr, t, f, 3)
+    print(renyi_information(tfr, t, f, 3))

--- a/tftb/processing/time_domain.py
+++ b/tftb/processing/time_domain.py
@@ -12,9 +12,9 @@ def loctime(sig):
     :Example:
     >>> x = amgauss(160, 80.0, 50.0)
     >>> tm, T = loctime(x)
-    >>> print tm
+    >>> print(tm)
     80.0
-    >>> print T
+    >>> print(T)
     50.0
     """
     if sig.ndim > 2:


### PR DESCRIPTION
Hi,
I tested pytftb with Python 3 on Debian unstable and came across a few minor print() issues and a missing int() cast. Fixing those I managed to get the Quick-start examples to work.
Cheers