### PR TITLE
specified matplotlib 2.2.4; added cariocffi and pgi which were required to import tftb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 numpy
 scipy
-matplotlib
+matplotlib==2.2.4
 sphinx-gallery
+cairocffi
+pgi


### PR DESCRIPTION
This addresses issue #163. Matplotlib 3.1.0, the current release does not include matplotlib.mlab.find. It appears that this was removed when matplotlib when from 2->3. Matplotlib 2.2.4 maintains python 2 compatibility, but is slated for deprecation when python 2 deprecates so this is a short-term fix. 

I was also required to added cairocffi and pgi in order to get matplotlib to import.